### PR TITLE
Add ability to override DataTables class via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,42 @@ return datatables()->provide(...);
 return \DataTables::provide(...);
 ```
 
+## Configuration and Extending DataTables
+
+You can publish the package configuration file to your application to override the default settings or extend package functionality.
+```php
+php artisan vendor:publish --provider="AdMos\DataTables\DataTablesServiceProvider" --tag="admos-datatables-config"
+```
+This will create the file **config/ad-mos-datatables.php** in your application.
+
+### Overriding the DataTables Class
+If you want to extend or customize the default DataTables behavior, you can create your own class that extends the built-in **DataTables**, and specify it in the configuration:
+
+**Example:**
+
+```php
+// app/DataTables/MyCustomDataTables.php
+
+namespace App\DataTables;
+
+use AdMos\DataTables\DataTables as BaseDataTables;
+
+class MyCustomDataTables extends BaseDataTables
+{
+    // Your customizations here
+}
+```
+
+Then, in your config/ad-mos-datatables.php file, set:
+
+```php
+return [
+    'class' => \App\DataTables\MyCustomDataTables::class,
+];
+```
+
+Now, when you use the DataTables service or helper, your custom implementation will be used automatically.
+
 ## License
 
 The MIT License. More information [here](https://github.com/ad-mos/laravel-datatables/blob/master/LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
     {
       "name": "Adam Mospan",
       "email": "adammospan@gmail.com"
+    },
+    {
+      "name": "Yaroslav Romanenko",
+      "email": "yaroslav.romanenko@gmail.com"
     }
   ],
   "require": {

--- a/config/ad-mos-datatables.php
+++ b/config/ad-mos-datatables.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    /*
+   |--------------------------------------------------------------------------
+   | DataTables Class
+   |--------------------------------------------------------------------------
+   |
+   | Here you may specify the class that should be used as the main DataTables
+   | handler. This allows you to extend or override the default behavior by
+   | providing your own implementation. Just set the value to the fully
+   | qualified class name of your custom DataTables class.
+   |
+   | Default: \AdMos\DataTables\DataTables::class
+   */
+    'class' => \AdMos\DataTables\DataTables::class,
+];

--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -12,22 +12,39 @@ class DataTablesServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $app = $this->app;
 
-        $app->alias('datatables', DataTables::class);
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/ad-mos-datatables.php', 'ad-mos-datatables'
+        );
 
-        $app->singleton('datatables', function () use ($app) {
-            return new DataTables(
+        $class = config('ad-mos-datatables.class', DataTables::class);
+
+        $app->alias('datatables', $class);
+
+        $app->singleton('datatables', function () use ($app, $class) {
+            return new $class(
                 $app->make('request'),
                 $app->make(DatabaseManager::class)
             );
         });
     }
 
-    public function boot()
+
+
+    public function boot(): void
     {
-        //
+        $this->offerPublishing();
+    }
+
+    protected function offerPublishing(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/ad-mos-datatables.php' => config_path('ad-mos-datatables.php'),
+            ], 'admos-datatables-config');
+        }
     }
 }


### PR DESCRIPTION
- Added config/ad-mos-datatables.php configuration file
- Registered config publishing in DataTablesServiceProvider
- Resolved DataTables singleton class from config, allowing users to extend or replace core functionality
- Updated README with instructions for publishing config and overriding the DataTables class
